### PR TITLE
perf: 共享连接池 + web_fetch 对冲抓取 + 多 key failover 重构

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,11 @@ GROK_API_KEY=your-grok-api-key
 # FIRECRAWL_API_KEYS=fc-key-1,fc-key-2
 # FIRECRAWL_API_URL=https://api.firecrawl.dev/v2
 
+# ====== 可选：web_fetch 对冲抓取 ======
+# Tavily 超过该秒数未返回时，并行追加 Firecrawl，谁先出结果用谁。
+# 设 0 表示两者始终并发（最快，但每次都耗 Firecrawl 额度）
+# GROK_FETCH_HEDGE_DELAY=8
+
 # ====== 可选：调试 / 日志 / 重试 ======
 # GROK_DEBUG=false
 # GROK_LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The `.env` file defaults to the script's own directory. Override with `GROK_SEAR
 | `TAVILY_API_URL` | No | `https://api.tavily.com` | Tavily endpoint |
 | `FIRECRAWL_API_KEYS` | No | — | Comma-separated Firecrawl keys; fallback: `FIRECRAWL_SCREENSHOT_API_KEYS` |
 | `FIRECRAWL_API_URL` | No | `https://api.firecrawl.dev/v2` | Firecrawl endpoint |
+| `GROK_FETCH_HEDGE_DELAY` | No | `8` | `web_fetch` hedge delay in seconds: if Tavily hasn't answered in time, Firecrawl is raced in parallel; `0` means always race both |
 | `GROK_DEBUG` | No | `false` | Enable debug logging |
 | `GROK_LOG_LEVEL` / `GROK_LOG_DIR` | No | `INFO` / `logs` | Log level / log directory |
 | `GROK_RETRY_MAX_ATTEMPTS` / `GROK_RETRY_MULTIPLIER` / `GROK_RETRY_MAX_WAIT` | No | `3` / `1` / `10` | Retry policy |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -95,6 +95,7 @@ claude mcp add-json grok-search --scope user '{
 | `TAVILY_API_URL` | — | `https://api.tavily.com` | Tavily 端点 |
 | `FIRECRAWL_API_KEYS` | — | — | Firecrawl key，逗号分隔；兼容回落 `FIRECRAWL_SCREENSHOT_API_KEYS` |
 | `FIRECRAWL_API_URL` | — | `https://api.firecrawl.dev/v2` | Firecrawl 端点 |
+| `GROK_FETCH_HEDGE_DELAY` | — | `8` | `web_fetch` 对冲延迟（秒）：Tavily 超时未返回则并行追加 Firecrawl；设 `0` 为始终并发 |
 | `GROK_DEBUG` | — | `false` | 调试日志开关 |
 | `GROK_LOG_LEVEL` / `GROK_LOG_DIR` | — | `INFO` / `logs` | 日志级别/目录 |
 | `GROK_RETRY_MAX_ATTEMPTS` / `GROK_RETRY_MULTIPLIER` / `GROK_RETRY_MAX_WAIT` | — | `3` / `1` / `10` | 重试策略 |

--- a/src/grok_search/config.py
+++ b/src/grok_search/config.py
@@ -59,6 +59,15 @@ class Config:
         return int(os.getenv("GROK_RETRY_MAX_WAIT", "10"))
 
     @property
+    def fetch_hedge_delay(self) -> float:
+        """web_fetch 对冲延迟（秒）：Tavily 超过该时长未返回时并行追加 Firecrawl。
+        设为 0 表示两者始终并发（更快但多耗 Firecrawl 额度）。"""
+        try:
+            return max(0.0, float(os.getenv("GROK_FETCH_HEDGE_DELAY", "8")))
+        except ValueError:
+            return 8.0
+
+    @property
     def grok_api_url(self) -> str:
         url = os.getenv("GROK_API_URL")
         if not url:

--- a/src/grok_search/firecrawl_client.py
+++ b/src/grok_search/firecrawl_client.py
@@ -1,22 +1,33 @@
 import httpx
+
 from .config import config
+from .http_client import get_client
 from .key_pool import pick_failover_key, mark_key_failed, mask_tail
 from .logger import log_info
 
+_KEY_ERROR_STATUS = (401, 403, 429)
+
+
+def _headers(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
 
 async def firecrawl_search(query: str, limit: int = 14) -> list[dict] | None:
-    api_key = pick_failover_key(config.firecrawl_api_keys, label="firecrawl-search")
-    if not api_key:
+    keys = config.firecrawl_api_keys
+    if not keys:
         return None
     endpoint = f"{config.firecrawl_api_url.rstrip('/')}/search"
-    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
     body = {"query": query, "limit": limit}
-    try:
-        async with httpx.AsyncClient(timeout=90.0) as client:
-            response = await client.post(endpoint, headers=headers, json=body)
-            if response.status_code in (401, 403, 429):
+    client = get_client()
+    for _ in range(len(keys)):
+        api_key = pick_failover_key(keys, label="firecrawl-search")
+        if not api_key:
+            return None
+        try:
+            response = await client.post(endpoint, headers=_headers(api_key), json=body, timeout=90.0)
+            if response.status_code in _KEY_ERROR_STATUS:
                 mark_key_failed(api_key)
-                return None
+                continue
             response.raise_for_status()
             data = response.json()
             results = data.get("data", {}).get("web", [])
@@ -24,22 +35,22 @@ async def firecrawl_search(query: str, limit: int = 14) -> list[dict] | None:
                 {"title": r.get("title", ""), "url": r.get("url", ""), "description": r.get("description", "")}
                 for r in results
             ] if results else None
-    except Exception:
-        return None
+        except Exception:
+            return None
+    return None
 
 
 async def firecrawl_scrape(url: str, ctx=None) -> str | None:
-    api_url = config.firecrawl_api_url
     keys = config.firecrawl_api_keys
     if not keys:
         return None
-    endpoint = f"{api_url.rstrip('/')}/scrape"
+    endpoint = f"{config.firecrawl_api_url.rstrip('/')}/scrape"
     max_retries = config.retry_max_attempts
+    client = get_client()
     for attempt in range(max_retries):
         api_key = pick_failover_key(keys, label="firecrawl-scrape")
         if not api_key:
             return None
-        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
         body = {
             "url": url,
             "formats": ["markdown"],
@@ -47,18 +58,17 @@ async def firecrawl_scrape(url: str, ctx=None) -> str | None:
             "waitFor": (attempt + 1) * 1500,
         }
         try:
-            async with httpx.AsyncClient(timeout=90.0) as client:
-                response = await client.post(endpoint, headers=headers, json=body)
-                if response.status_code in (401, 403, 429):
-                    mark_key_failed(api_key)
-                    await log_info(ctx, f"Firecrawl scrape: key ...{mask_tail(api_key)} cooldown, 重试", config.debug_enabled)
-                    continue
-                response.raise_for_status()
-                data = response.json()
-                markdown = data.get("data", {}).get("markdown", "")
-                if markdown and markdown.strip():
-                    return markdown
-                await log_info(ctx, f"Firecrawl: markdown为空, 重试 {attempt + 1}/{max_retries}", config.debug_enabled)
+            response = await client.post(endpoint, headers=_headers(api_key), json=body, timeout=90.0)
+            if response.status_code in _KEY_ERROR_STATUS:
+                mark_key_failed(api_key)
+                await log_info(ctx, f"Firecrawl scrape: key ...{mask_tail(api_key)} cooldown, 重试", config.debug_enabled)
+                continue
+            response.raise_for_status()
+            data = response.json()
+            markdown = data.get("data", {}).get("markdown", "")
+            if markdown and markdown.strip():
+                return markdown
+            await log_info(ctx, f"Firecrawl: markdown为空, 重试 {attempt + 1}/{max_retries}", config.debug_enabled)
         except Exception as e:
             await log_info(ctx, f"Firecrawl error: {e}", config.debug_enabled)
             return None
@@ -68,46 +78,44 @@ async def firecrawl_scrape(url: str, ctx=None) -> str | None:
 async def firecrawl_screenshot(url: str, full_page: bool, ctx=None) -> dict | str:
     """Firecrawl /scrape 全页/首屏截图，多 key failover。
     成功返回 dict（含 screenshot_url 等元数据），失败返回中文错误描述字符串。"""
-    api_url = config.firecrawl_api_url
     keys = config.firecrawl_api_keys
     if not keys:
         return "配置错误: Firecrawl key 未配置（设 FIRECRAWL_API_KEYS / FIRECRAWL_API_KEY）"
-    endpoint = f"{api_url.rstrip('/')}/scrape"
+    endpoint = f"{config.firecrawl_api_url.rstrip('/')}/scrape"
     screenshot_format = {"type": "screenshot", "fullPage": True} if full_page else {"type": "screenshot"}
     body = {"url": url, "formats": [screenshot_format], "timeout": 60000}
+    client = get_client()
     last_error = None
     for _ in range(len(keys)):
         api_key = pick_failover_key(keys, label="firecrawl-screenshot")
         if not api_key:
             return last_error or f"截图失败: 所有 {len(keys)} 个 Firecrawl key 都在 cooldown 中（默认 30 分钟）"
-        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
         try:
-            async with httpx.AsyncClient(timeout=90.0) as client:
-                response = await client.post(endpoint, headers=headers, json=body)
-                if response.status_code in (401, 403, 429):
-                    mark_key_failed(api_key)
-                    last_error = f"HTTP错误: {response.status_code}（key ...{mask_tail(api_key)} 已 cooldown 30 分钟）"
-                    await log_info(ctx, f"Firecrawl screenshot: {last_error}, 尝试下一个 key", config.debug_enabled)
-                    continue
-                response.raise_for_status()
-                data = response.json()
-                inner = data.get("data") or {}
-                screenshot_url = inner.get("screenshot")
-                if not screenshot_url:
-                    await log_info(ctx, f"Firecrawl screenshot: 响应缺少 screenshot 字段, payload={data}", config.debug_enabled)
-                    return "截图失败: Firecrawl 未返回截图 URL"
-                meta = inner.get("metadata") or {}
-                return {
-                    "url": url,
-                    "screenshot_url": screenshot_url,
-                    "format": "screenshot@fullPage" if full_page else "screenshot",
-                    "title": meta.get("title"),
-                    "status_code": meta.get("statusCode"),
-                    "credits_used": meta.get("creditsUsed"),
-                    "cache_state": meta.get("cacheState"),
-                    "key_tail": mask_tail(api_key),
-                    "note": "screenshot_url 是 GCS 签名链接，会在数小时内过期，请尽快下载",
-                }
+            response = await client.post(endpoint, headers=_headers(api_key), json=body, timeout=90.0)
+            if response.status_code in _KEY_ERROR_STATUS:
+                mark_key_failed(api_key)
+                last_error = f"HTTP错误: {response.status_code}（key ...{mask_tail(api_key)} 已 cooldown 30 分钟）"
+                await log_info(ctx, f"Firecrawl screenshot: {last_error}, 尝试下一个 key", config.debug_enabled)
+                continue
+            response.raise_for_status()
+            data = response.json()
+            inner = data.get("data") or {}
+            screenshot_url = inner.get("screenshot")
+            if not screenshot_url:
+                await log_info(ctx, f"Firecrawl screenshot: 响应缺少 screenshot 字段, payload={data}", config.debug_enabled)
+                return "截图失败: Firecrawl 未返回截图 URL"
+            meta = inner.get("metadata") or {}
+            return {
+                "url": url,
+                "screenshot_url": screenshot_url,
+                "format": "screenshot@fullPage" if full_page else "screenshot",
+                "title": meta.get("title"),
+                "status_code": meta.get("statusCode"),
+                "credits_used": meta.get("creditsUsed"),
+                "cache_state": meta.get("cacheState"),
+                "key_tail": mask_tail(api_key),
+                "note": "screenshot_url 是 GCS 签名链接，会在数小时内过期，请尽快下载",
+            }
         except httpx.HTTPStatusError as e:
             await log_info(ctx, f"Firecrawl screenshot HTTP错误: {e.response.status_code} - {e.response.text[:200]}", config.debug_enabled)
             return f"HTTP错误: {e.response.status_code} - {e.response.text[:200]}"

--- a/src/grok_search/grok_client.py
+++ b/src/grok_search/grok_client.py
@@ -8,6 +8,7 @@ from tenacity.wait import wait_base
 from .prompts import search_prompt
 from .logger import log_info
 from .config import config
+from .http_client import get_client
 
 
 def get_local_time_info() -> str:
@@ -153,19 +154,20 @@ class GrokClient:
 
     async def _execute_stream_with_retry(self, headers: dict, payload: dict, ctx=None) -> str:
         timeout = httpx.Timeout(connect=6.0, read=120.0, write=10.0, pool=None)
-        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
-            async for attempt in AsyncRetrying(
-                stop=stop_after_attempt(config.retry_max_attempts + 1),
-                wait=_WaitWithRetryAfter(config.retry_multiplier, config.retry_max_wait),
-                retry=retry_if_exception(_is_retryable_exception),
-                reraise=True,
-            ):
-                with attempt:
-                    async with client.stream(
-                        "POST",
-                        f"{self.api_url}/chat/completions",
-                        headers=headers,
-                        json=payload,
-                    ) as response:
-                        response.raise_for_status()
-                        return await self._parse_streaming_response(response, ctx)
+        client = get_client()
+        async for attempt in AsyncRetrying(
+            stop=stop_after_attempt(config.retry_max_attempts + 1),
+            wait=_WaitWithRetryAfter(config.retry_multiplier, config.retry_max_wait),
+            retry=retry_if_exception(_is_retryable_exception),
+            reraise=True,
+        ):
+            with attempt:
+                async with client.stream(
+                    "POST",
+                    f"{self.api_url}/chat/completions",
+                    headers=headers,
+                    json=payload,
+                    timeout=timeout,
+                ) as response:
+                    response.raise_for_status()
+                    return await self._parse_streaming_response(response, ctx)

--- a/src/grok_search/http_client.py
+++ b/src/grok_search/http_client.py
@@ -1,0 +1,39 @@
+"""进程级共享 httpx.AsyncClient：连接池 + keep-alive 复用。
+
+之前每次工具调用都临时新建 AsyncClient，每个请求都要重做 TCP + TLS 握手。
+现在按事件循环缓存客户端，同一 loop 内所有请求（Grok / Tavily / Firecrawl /
+配置探针）复用同一个连接池，对同一主机的连续请求可以直接走 keep-alive 连接。
+
+各调用方通过 per-request 的 timeout 参数覆盖默认超时，不再需要各自建客户端。
+"""
+
+import asyncio
+
+import httpx
+
+_LIMITS = httpx.Limits(
+    max_connections=64,
+    max_keepalive_connections=20,
+    keepalive_expiry=30.0,
+)
+_DEFAULT_TIMEOUT = httpx.Timeout(connect=6.0, read=90.0, write=10.0, pool=None)
+
+_clients: dict[int, httpx.AsyncClient] = {}
+
+
+def get_client() -> httpx.AsyncClient:
+    """返回绑定到当前事件循环的共享客户端（懒创建）。
+
+    按 loop 区分是为了兼容测试等多 loop 场景——httpx 客户端不能跨 loop 使用。
+    stdio 服务器整个生命周期只有一个 loop，所以实际只会创建一个客户端。
+    """
+    loop_id = id(asyncio.get_running_loop())
+    client = _clients.get(loop_id)
+    if client is None or client.is_closed:
+        client = httpx.AsyncClient(
+            limits=_LIMITS,
+            timeout=_DEFAULT_TIMEOUT,
+            follow_redirects=True,
+        )
+        _clients[loop_id] = client
+    return client

--- a/src/grok_search/logger.py
+++ b/src/grok_search/logger.py
@@ -24,8 +24,12 @@ except OSError:
     logger.addHandler(logging.NullHandler())
 
 async def log_info(ctx, message: str, is_debug: bool = False):
-    if is_debug:
-        logger.info(message)
-        
+    """仅在 debug 开启时写文件日志并向客户端推送 MCP 通知。
+
+    非 debug 路径零开销：之前无论是否 debug 都会对每条消息发一次 ctx.info
+    通知（包括整段搜索结果正文），白白增加每次调用的往返和序列化成本。"""
+    if not is_debug:
+        return
+    logger.info(message)
     if ctx:
         await ctx.info(message)

--- a/src/grok_search/server.py
+++ b/src/grok_search/server.py
@@ -1,6 +1,10 @@
 import sys
 import asyncio
+import json
+import time
 from pathlib import Path
+
+import httpx
 
 src_dir = Path(__file__).parent.parent
 if str(src_dir) not in sys.path:
@@ -14,6 +18,7 @@ try:
     from grok_search.grok_client import GrokClient
     from grok_search.logger import log_info
     from grok_search.config import config
+    from grok_search.http_client import get_client
     from grok_search.sources import SourcesCache, merge_sources, new_session_id, split_answer_and_sources
     from grok_search.key_pool import cooldown_status
     from grok_search.tavily_client import tavily_extract, tavily_search, tavily_map
@@ -22,6 +27,7 @@ except ImportError:
     from .grok_client import GrokClient
     from .logger import log_info
     from .config import config
+    from .http_client import get_client
     from .sources import SourcesCache, merge_sources, new_session_id, split_answer_and_sources
     from .key_pool import cooldown_status
     from .tavily_client import tavily_extract, tavily_search, tavily_map
@@ -30,20 +36,22 @@ except ImportError:
 mcp = FastMCP("grok-search")
 
 _SOURCES_CACHE = SourcesCache(max_size=256)
-_AVAILABLE_MODELS_CACHE: dict[tuple[str, str], list[str]] = {}
+# (api_url, api_key) -> (缓存时间戳, 模型列表)。带 TTL，且拉取失败不写缓存，
+# 避免一次网络抖动导致模型校验永久失效（旧实现把空列表缓存到进程结束）。
+_AVAILABLE_MODELS_CACHE: dict[tuple[str, str], tuple[float, list[str]]] = {}
 _AVAILABLE_MODELS_LOCK = asyncio.Lock()
+_AVAILABLE_MODELS_TTL = 600.0
 
 
 async def _fetch_available_models(api_url: str, api_key: str) -> list[str]:
-    import httpx
     models_url = f"{api_url.rstrip('/')}/models"
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        response = await client.get(
-            models_url,
-            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-        )
-        response.raise_for_status()
-        data = response.json()
+    response = await get_client().get(
+        models_url,
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+    data = response.json()
     models: list[str] = []
     for item in (data or {}).get("data", []) or []:
         if isinstance(item, dict) and isinstance(item.get("id"), str):
@@ -53,16 +61,36 @@ async def _fetch_available_models(api_url: str, api_key: str) -> list[str]:
 
 async def _get_available_models_cached(api_url: str, api_key: str) -> list[str]:
     key = (api_url, api_key)
+    now = time.monotonic()
     async with _AVAILABLE_MODELS_LOCK:
-        if key in _AVAILABLE_MODELS_CACHE:
-            return _AVAILABLE_MODELS_CACHE[key]
+        cached = _AVAILABLE_MODELS_CACHE.get(key)
+        if cached and now - cached[0] < _AVAILABLE_MODELS_TTL:
+            return cached[1]
     try:
         models = await _fetch_available_models(api_url, api_key)
     except Exception:
-        models = []
+        return []
     async with _AVAILABLE_MODELS_LOCK:
-        _AVAILABLE_MODELS_CACHE[key] = models
+        _AVAILABLE_MODELS_CACHE[key] = (time.monotonic(), models)
     return models
+
+
+def _split_extra_counts(extra_sources: int, has_tavily: bool, has_firecrawl: bool) -> tuple[int, int]:
+    """把 extra_sources 分配给 (tavily, firecrawl) 两个引擎。
+
+    两者都可用时对半分（Firecrawl 拿多的那半），让补充信源来自两个独立
+    搜索引擎，覆盖面更广；旧实现的 round(extra_sources * 1) 会把全部名额
+    给 Firecrawl，Tavily 永远分到 0。"""
+    if extra_sources <= 0:
+        return 0, 0
+    if has_tavily and has_firecrawl:
+        firecrawl_count = (extra_sources + 1) // 2
+        return extra_sources - firecrawl_count, firecrawl_count
+    if has_firecrawl:
+        return 0, extra_sources
+    if has_tavily:
+        return extra_sources, 0
+    return 0, 0
 
 
 def _extra_results_to_sources(tavily_results, firecrawl_results) -> list[dict]:
@@ -136,18 +164,9 @@ async def web_search(
 
     grok = GrokClient(api_url, api_key, effective_model)
 
-    has_tavily = bool(config.tavily_api_keys)
-    has_firecrawl = bool(config.firecrawl_api_keys)
-    firecrawl_count = 0
-    tavily_count = 0
-    if extra_sources > 0:
-        if has_firecrawl and has_tavily:
-            firecrawl_count = round(extra_sources * 1)
-            tavily_count = extra_sources - firecrawl_count
-        elif has_firecrawl:
-            firecrawl_count = extra_sources
-        elif has_tavily:
-            tavily_count = extra_sources
+    tavily_count, firecrawl_count = _split_extra_counts(
+        extra_sources, bool(config.tavily_api_keys), bool(config.firecrawl_api_keys)
+    )
 
     async def _safe_grok() -> str:
         try:
@@ -155,37 +174,15 @@ async def web_search(
         except Exception:
             return ""
 
-    async def _safe_tavily():
-        try:
-            if tavily_count:
-                return await tavily_search(query, tavily_count)
-        except Exception:
-            return None
+    # tavily_search / firecrawl_search 内部已吞掉所有异常并返回 None，
+    # 这里直接建 task 并发跑，按名字取结果，不再依赖 gather 的位置索引。
+    grok_task = asyncio.create_task(_safe_grok())
+    tavily_task = asyncio.create_task(tavily_search(query, tavily_count)) if tavily_count > 0 else None
+    firecrawl_task = asyncio.create_task(firecrawl_search(query, firecrawl_count)) if firecrawl_count > 0 else None
 
-    async def _safe_firecrawl():
-        try:
-            if firecrawl_count:
-                return await firecrawl_search(query, firecrawl_count)
-        except Exception:
-            return None
-
-    coros = [_safe_grok()]
-    if tavily_count > 0:
-        coros.append(_safe_tavily())
-    if firecrawl_count > 0:
-        coros.append(_safe_firecrawl())
-
-    gathered = await asyncio.gather(*coros)
-
-    grok_result: str = gathered[0] or ""
-    tavily_results = None
-    firecrawl_results = None
-    idx = 1
-    if tavily_count > 0:
-        tavily_results = gathered[idx]
-        idx += 1
-    if firecrawl_count > 0:
-        firecrawl_results = gathered[idx]
+    grok_result: str = (await grok_task) or ""
+    tavily_results = await tavily_task if tavily_task else None
+    firecrawl_results = await firecrawl_task if firecrawl_task else None
 
     answer, grok_sources = split_answer_and_sources(grok_result)
     extra = _extra_results_to_sources(tavily_results, firecrawl_results)
@@ -240,20 +237,57 @@ async def web_fetch(
     url: Annotated[str, "Valid HTTP/HTTPS web address pointing to the target page. Must be complete and accessible."],
     ctx: Context = None,
 ) -> str:
+    has_tavily = bool(config.tavily_api_keys)
+    has_firecrawl = bool(config.firecrawl_api_keys)
+    if not has_tavily and not has_firecrawl:
+        return "配置错误: TAVILY_API_KEYS 和 FIRECRAWL_API_KEYS 均未配置"
+
     await log_info(ctx, f"Begin Fetch: {url}", config.debug_enabled)
-    result = await tavily_extract(url)
+    if not has_firecrawl:
+        result = await tavily_extract(url)
+    elif not has_tavily:
+        result = await firecrawl_scrape(url, ctx)
+    else:
+        result = await _hedged_fetch(url, ctx)
+
     if result:
-        await log_info(ctx, "Fetch Finished (Tavily)!", config.debug_enabled)
-        return result
-    await log_info(ctx, "Tavily unavailable or failed, trying Firecrawl...", config.debug_enabled)
-    result = await firecrawl_scrape(url, ctx)
-    if result:
-        await log_info(ctx, "Fetch Finished (Firecrawl)!", config.debug_enabled)
+        await log_info(ctx, "Fetch Finished!", config.debug_enabled)
         return result
     await log_info(ctx, "Fetch Failed!", config.debug_enabled)
-    if not config.tavily_api_keys and not config.firecrawl_api_keys:
-        return "配置错误: TAVILY_API_KEYS 和 FIRECRAWL_API_KEYS 均未配置"
     return "提取失败: 所有提取服务均未能获取内容"
+
+
+async def _hedged_fetch(url: str, ctx=None) -> str | None:
+    """对冲式抓取：先发 Tavily；超过 GROK_FETCH_HEDGE_DELAY 秒仍未返回，
+    并行追加 Firecrawl，谁先出有效内容用谁，另一方立即取消。
+
+    相比旧的串行降级（Tavily 最长等 60 秒失败后才轮到 Firecrawl），慢站点
+    最坏等待从「Tavily 超时 + Firecrawl 全程」缩短为约「hedge 延迟 + 较快
+    一方的耗时」；Tavily 在延迟窗口内正常返回时行为不变，不多耗额度。"""
+    tavily_task = asyncio.create_task(tavily_extract(url))
+    done, _ = await asyncio.wait({tavily_task}, timeout=config.fetch_hedge_delay)
+
+    if tavily_task in done:
+        result = tavily_task.result()
+        if result:
+            return result
+        # Tavily 快速失败 → 直接走 Firecrawl，无需对冲
+        return await firecrawl_scrape(url, ctx)
+
+    await log_info(ctx, "Tavily slow, hedging with Firecrawl...", config.debug_enabled)
+    firecrawl_task = asyncio.create_task(firecrawl_scrape(url, ctx))
+    pending = {tavily_task, firecrawl_task}
+    result = None
+    while pending and not result:
+        done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+        for task in done:
+            value = task.result()
+            if value:
+                result = value
+                break
+    for task in pending:
+        task.cancel()
+    return result
 
 
 @mcp.tool(
@@ -279,7 +313,6 @@ async def web_screenshot(
     full_page: Annotated[bool, "If True, capture the entire scrollable page; otherwise just the viewport (first fold). Default False."] = False,
     ctx: Context = None,
 ) -> str:
-    import json
     await log_info(ctx, f"Begin Screenshot: {url} (full_page={full_page})", config.debug_enabled)
     result = await firecrawl_screenshot(url, full_page, ctx)
     if isinstance(result, dict):
@@ -335,42 +368,53 @@ async def web_map(
     meta={"version": "1.3.0"},
 )
 async def get_config_info() -> str:
-    import json
-    import httpx
-    import time
-
     config_info = config.get_config_info()
 
+    # 两个探针互相独立，并发执行：总耗时从「连接测试 + 模型探针」之和
+    # 缩短为两者中较慢的一个。
+    connection_test, default_model_health = await asyncio.gather(
+        _probe_models_endpoint(), _probe_default_model()
+    )
+    config_info["connection_test"] = connection_test
+    config_info["default_model_health"] = default_model_health
+
+    config_info["tavily_key_cooldown"] = cooldown_status(config.tavily_api_keys)
+    config_info["firecrawl_key_cooldown"] = cooldown_status(config.firecrawl_api_keys)
+
+    return json.dumps(config_info, ensure_ascii=False, indent=2)
+
+
+async def _probe_models_endpoint() -> dict:
     test_result = {"status": "未测试", "message": "", "response_time_ms": 0}
     try:
         api_url = config.grok_api_url
         api_key = config.grok_api_key
         models_url = f"{api_url.rstrip('/')}/models"
-        start_time = time.time()
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.get(
-                models_url,
-                headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-            )
-            response_time = (time.time() - start_time) * 1000
-            if response.status_code == 200:
-                test_result["status"] = "✅ 连接成功"
-                test_result["message"] = f"成功获取模型列表 (HTTP {response.status_code})"
-                test_result["response_time_ms"] = round(response_time, 2)
-                try:
-                    models_data = response.json()
-                    if "data" in models_data and isinstance(models_data["data"], list):
-                        model_count = len(models_data["data"])
-                        test_result["message"] += f"，共 {model_count} 个模型"
-                        model_names = [m["id"] for m in models_data["data"] if isinstance(m, dict) and "id" in m]
-                        if model_names:
-                            test_result["available_models"] = model_names
-                except Exception:
-                    pass
-            else:
-                test_result["status"] = "⚠️ 连接异常"
-                test_result["message"] = f"HTTP {response.status_code}: {response.text[:100]}"
-                test_result["response_time_ms"] = round(response_time, 2)
+        start_time = time.monotonic()
+        response = await get_client().get(
+            models_url,
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            timeout=10.0,
+        )
+        response_time = (time.monotonic() - start_time) * 1000
+        if response.status_code == 200:
+            test_result["status"] = "✅ 连接成功"
+            test_result["message"] = f"成功获取模型列表 (HTTP {response.status_code})"
+            test_result["response_time_ms"] = round(response_time, 2)
+            try:
+                models_data = response.json()
+                if "data" in models_data and isinstance(models_data["data"], list):
+                    model_count = len(models_data["data"])
+                    test_result["message"] += f"，共 {model_count} 个模型"
+                    model_names = [m["id"] for m in models_data["data"] if isinstance(m, dict) and "id" in m]
+                    if model_names:
+                        test_result["available_models"] = model_names
+            except Exception:
+                pass
+        else:
+            test_result["status"] = "⚠️ 连接异常"
+            test_result["message"] = f"HTTP {response.status_code}: {response.text[:100]}"
+            test_result["response_time_ms"] = round(response_time, 2)
     except httpx.TimeoutException:
         test_result["status"] = "❌ 连接超时"
         test_result["message"] = "请求超时（10秒），请检查网络连接或 API URL"
@@ -383,8 +427,10 @@ async def get_config_info() -> str:
     except Exception as e:
         test_result["status"] = "❌ 测试失败"
         test_result["message"] = f"未知错误: {str(e)}"
-    config_info["connection_test"] = test_result
+    return test_result
 
+
+async def _probe_default_model() -> dict:
     default_model_health = {"model": "未配置", "status": "未测试", "response_time_ms": 0, "message": ""}
     try:
         api_url = config.grok_api_url
@@ -392,35 +438,30 @@ async def get_config_info() -> str:
         model = config.grok_model
         default_model_health["model"] = model
         probe_payload = {"model": model, "stream": False, "max_tokens": 1, "messages": [{"role": "user", "content": "ping"}]}
-        _start = time.time()
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{api_url.rstrip('/')}/chat/completions",
-                headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-                json=probe_payload,
-            )
-            default_model_health["response_time_ms"] = round((time.time() - _start) * 1000, 2)
-            text = resp.text or ""
-            if "No available accounts" in text or "rate_limit_exceeded" in text:
-                default_model_health["status"] = "❌ 中转站无账号"
-                default_model_health["message"] = "该模型在中转站没有可用账号，建议切换其他模型"
-            elif resp.status_code == 200:
-                default_model_health["status"] = "✅ 可用"
-                default_model_health["message"] = "1-token 探针通过"
-            else:
-                default_model_health["status"] = f"⚠️ HTTP {resp.status_code}"
-                default_model_health["message"] = text[:200]
+        start_time = time.monotonic()
+        resp = await get_client().post(
+            f"{api_url.rstrip('/')}/chat/completions",
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            json=probe_payload,
+            timeout=10.0,
+        )
+        default_model_health["response_time_ms"] = round((time.monotonic() - start_time) * 1000, 2)
+        text = resp.text or ""
+        if "No available accounts" in text or "rate_limit_exceeded" in text:
+            default_model_health["status"] = "❌ 中转站无账号"
+            default_model_health["message"] = "该模型在中转站没有可用账号，建议切换其他模型"
+        elif resp.status_code == 200:
+            default_model_health["status"] = "✅ 可用"
+            default_model_health["message"] = "1-token 探针通过"
+        else:
+            default_model_health["status"] = f"⚠️ HTTP {resp.status_code}"
+            default_model_health["message"] = text[:200]
     except httpx.TimeoutException:
         default_model_health["status"] = "❌ 探针超时"
     except Exception as e:
         default_model_health["status"] = "❌ 探针失败"
         default_model_health["message"] = str(e)[:200]
-    config_info["default_model_health"] = default_model_health
-
-    config_info["tavily_key_cooldown"] = cooldown_status(config.tavily_api_keys)
-    config_info["firecrawl_key_cooldown"] = cooldown_status(config.firecrawl_api_keys)
-
-    return json.dumps(config_info, ensure_ascii=False, indent=2)
+    return default_model_health
 
 
 @mcp.tool(
@@ -444,7 +485,6 @@ async def get_config_info() -> str:
 async def switch_model(
     model: Annotated[str, "Model ID to switch to (e.g., 'grok-4.3-console', 'grok-4.20-fast')."]
 ) -> str:
-    import json
     try:
         previous_model = config.grok_model
         config.set_model(model)
@@ -483,7 +523,6 @@ async def switch_model(
 async def toggle_builtin_tools(
     action: Annotated[str, "Action to perform: 'on' (block built-in), 'off' (allow built-in), or 'status' (check current state)."] = "status"
 ) -> str:
-    import json
     root = Path.cwd()
     while root != root.parent and not (root / ".git").exists():
         root = root.parent

--- a/src/grok_search/tavily_client.py
+++ b/src/grok_search/tavily_client.py
@@ -1,39 +1,53 @@
 import json
+
 import httpx
+
 from .config import config
+from .http_client import get_client
 from .key_pool import pick_tavily_key, mark_key_failed
+
+# key 级错误（额度耗尽 / 被吊销 / 限速）：冷却当前 key 并立刻换下一个重试，
+# 其余错误（超时 / 网络 / 目标站问题）换 key 也没用，直接返回。
+_KEY_ERROR_STATUS = (401, 403, 429)
+
+
+def _headers(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
 
 
 async def tavily_extract(url: str) -> str | None:
-    api_url = config.tavily_api_url
-    api_key = pick_tavily_key(config.tavily_api_keys)
-    if not api_key:
+    keys = config.tavily_api_keys
+    if not keys:
         return None
-    endpoint = f"{api_url.rstrip('/')}/extract"
-    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    endpoint = f"{config.tavily_api_url.rstrip('/')}/extract"
     body = {"urls": [url], "format": "markdown"}
-    try:
-        async with httpx.AsyncClient(timeout=60.0) as client:
-            response = await client.post(endpoint, headers=headers, json=body)
-            if response.status_code in (401, 403, 429):
+    client = get_client()
+    for _ in range(len(keys)):
+        api_key = pick_tavily_key(keys)
+        if not api_key:
+            return None
+        try:
+            response = await client.post(endpoint, headers=_headers(api_key), json=body, timeout=60.0)
+            if response.status_code in _KEY_ERROR_STATUS:
                 mark_key_failed(api_key)
-                return None
+                continue
             response.raise_for_status()
             data = response.json()
-            if data.get("results") and len(data["results"]) > 0:
-                content = data["results"][0].get("raw_content", "")
+            results = data.get("results") or []
+            if results:
+                content = results[0].get("raw_content", "")
                 return content if content and content.strip() else None
             return None
-    except Exception:
-        return None
+        except Exception:
+            return None
+    return None
 
 
 async def tavily_search(query: str, max_results: int = 6) -> list[dict] | None:
-    api_key = pick_tavily_key(config.tavily_api_keys)
-    if not api_key:
+    keys = config.tavily_api_keys
+    if not keys:
         return None
     endpoint = f"{config.tavily_api_url.rstrip('/')}/search"
-    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
     body = {
         "query": query,
         "max_results": max_results,
@@ -41,12 +55,16 @@ async def tavily_search(query: str, max_results: int = 6) -> list[dict] | None:
         "include_raw_content": False,
         "include_answer": False,
     }
-    try:
-        async with httpx.AsyncClient(timeout=90.0) as client:
-            response = await client.post(endpoint, headers=headers, json=body)
-            if response.status_code in (401, 403, 429):
+    client = get_client()
+    for _ in range(len(keys)):
+        api_key = pick_tavily_key(keys)
+        if not api_key:
+            return None
+        try:
+            response = await client.post(endpoint, headers=_headers(api_key), json=body, timeout=90.0)
+            if response.status_code in _KEY_ERROR_STATUS:
                 mark_key_failed(api_key)
-                return None
+                continue
             response.raise_for_status()
             data = response.json()
             results = data.get("results", [])
@@ -54,27 +72,32 @@ async def tavily_search(query: str, max_results: int = 6) -> list[dict] | None:
                 {"title": r.get("title", ""), "url": r.get("url", ""), "content": r.get("content", ""), "score": r.get("score", 0)}
                 for r in results
             ] if results else None
-    except Exception:
-        return None
+        except Exception:
+            return None
+    return None
 
 
 async def tavily_map(url: str, instructions: str = None, max_depth: int = 1,
                      max_breadth: int = 20, limit: int = 50, timeout: int = 150) -> str:
-    api_url = config.tavily_api_url
-    api_key = pick_tavily_key(config.tavily_api_keys)
-    if not api_key:
+    keys = config.tavily_api_keys
+    if not keys:
         return "配置错误: TAVILY_API_KEY 未配置，请设置环境变量 TAVILY_API_KEYS"
-    endpoint = f"{api_url.rstrip('/')}/map"
-    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    endpoint = f"{config.tavily_api_url.rstrip('/')}/map"
     body = {"url": url, "max_depth": max_depth, "max_breadth": max_breadth, "limit": limit, "timeout": timeout}
     if instructions:
         body["instructions"] = instructions
-    try:
-        async with httpx.AsyncClient(timeout=float(timeout + 10)) as client:
-            response = await client.post(endpoint, headers=headers, json=body)
-            if response.status_code in (401, 403, 429):
+    client = get_client()
+    for _ in range(len(keys)):
+        api_key = pick_tavily_key(keys)
+        if not api_key:
+            return f"映射失败: 所有 {len(keys)} 个 Tavily key 都在 cooldown 中"
+        try:
+            response = await client.post(
+                endpoint, headers=_headers(api_key), json=body, timeout=float(timeout + 10)
+            )
+            if response.status_code in _KEY_ERROR_STATUS:
                 mark_key_failed(api_key)
-                return f"HTTP错误: {response.status_code}（key 已暂时移出轮询池）"
+                continue
             response.raise_for_status()
             data = response.json()
             return json.dumps({
@@ -82,9 +105,10 @@ async def tavily_map(url: str, instructions: str = None, max_depth: int = 1,
                 "results": data.get("results", []),
                 "response_time": data.get("response_time", 0),
             }, ensure_ascii=False, indent=2)
-    except httpx.TimeoutException:
-        return f"映射超时: 请求超过{timeout}秒"
-    except httpx.HTTPStatusError as e:
-        return f"HTTP错误: {e.response.status_code} - {e.response.text[:200]}"
-    except Exception as e:
-        return f"映射错误: {str(e)}"
+        except httpx.TimeoutException:
+            return f"映射超时: 请求超过{timeout}秒"
+        except httpx.HTTPStatusError as e:
+            return f"HTTP错误: {e.response.status_code} - {e.response.text[:200]}"
+        except Exception as e:
+            return f"映射错误: {str(e)}"
+    return f"映射失败: 所有 {len(keys)} 个 Tavily key 均被拒（已进入 cooldown）"

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -1,0 +1,175 @@
+"""覆盖性能/精准度重构引入的新行为：
+- web_fetch 对冲抓取（_hedged_fetch）
+- extra_sources 在 Tavily / Firecrawl 之间的分配
+- 可用模型缓存的 TTL 与失败不缓存
+- Tavily 客户端遇 key 级错误自动换 key 重试
+"""
+
+import asyncio
+
+import httpx
+import pytest
+
+import grok_search.server as server
+import grok_search.key_pool as kp
+
+
+def setup_function():
+    kp._state["keys"] = None
+    kp._state["cycle"] = None
+    kp._cooldown.clear()
+    server._AVAILABLE_MODELS_CACHE.clear()
+
+
+# ---------- extra_sources 分配 ----------
+
+def test_split_extra_counts_both_providers_split():
+    tavily, firecrawl = server._split_extra_counts(6, has_tavily=True, has_firecrawl=True)
+    assert tavily == 3 and firecrawl == 3
+
+    tavily, firecrawl = server._split_extra_counts(5, has_tavily=True, has_firecrawl=True)
+    assert tavily == 2 and firecrawl == 3
+    assert tavily + firecrawl == 5
+
+
+def test_split_extra_counts_single_provider():
+    assert server._split_extra_counts(4, True, False) == (4, 0)
+    assert server._split_extra_counts(4, False, True) == (0, 4)
+    assert server._split_extra_counts(4, False, False) == (0, 0)
+    assert server._split_extra_counts(0, True, True) == (0, 0)
+
+
+# ---------- web_fetch 对冲 ----------
+
+@pytest.mark.asyncio
+async def test_hedged_fetch_tavily_fast_wins(monkeypatch):
+    """Tavily 在延迟窗口内返回 → 直接用，不动 Firecrawl。"""
+    monkeypatch.setenv("GROK_FETCH_HEDGE_DELAY", "1")
+    firecrawl_called = False
+
+    async def fake_tavily(url):
+        return "tavily-content"
+
+    async def fake_firecrawl(url, ctx=None):
+        nonlocal firecrawl_called
+        firecrawl_called = True
+        return "firecrawl-content"
+
+    monkeypatch.setattr(server, "tavily_extract", fake_tavily)
+    monkeypatch.setattr(server, "firecrawl_scrape", fake_firecrawl)
+
+    assert await server._hedged_fetch("https://x.com") == "tavily-content"
+    assert not firecrawl_called
+
+
+@pytest.mark.asyncio
+async def test_hedged_fetch_slow_tavily_loses_to_firecrawl(monkeypatch):
+    """Tavily 超过对冲延迟仍未返回 → Firecrawl 并行追加并胜出。"""
+    monkeypatch.setenv("GROK_FETCH_HEDGE_DELAY", "0.05")
+
+    async def slow_tavily(url):
+        await asyncio.sleep(5)
+        return "tavily-content"
+
+    async def fake_firecrawl(url, ctx=None):
+        return "firecrawl-content"
+
+    monkeypatch.setattr(server, "tavily_extract", slow_tavily)
+    monkeypatch.setattr(server, "firecrawl_scrape", fake_firecrawl)
+
+    assert await server._hedged_fetch("https://x.com") == "firecrawl-content"
+
+
+@pytest.mark.asyncio
+async def test_hedged_fetch_tavily_fast_failure_falls_back(monkeypatch):
+    """Tavily 快速失败（返回 None）→ 立即降级 Firecrawl，无需等对冲延迟。"""
+    monkeypatch.setenv("GROK_FETCH_HEDGE_DELAY", "30")
+
+    async def failing_tavily(url):
+        return None
+
+    async def fake_firecrawl(url, ctx=None):
+        return "firecrawl-content"
+
+    monkeypatch.setattr(server, "tavily_extract", failing_tavily)
+    monkeypatch.setattr(server, "firecrawl_scrape", fake_firecrawl)
+
+    assert await server._hedged_fetch("https://x.com") == "firecrawl-content"
+
+
+@pytest.mark.asyncio
+async def test_hedged_fetch_both_fail_returns_none(monkeypatch):
+    monkeypatch.setenv("GROK_FETCH_HEDGE_DELAY", "0.05")
+
+    async def slow_failing_tavily(url):
+        await asyncio.sleep(0.2)
+        return None
+
+    async def failing_firecrawl(url, ctx=None):
+        return None
+
+    monkeypatch.setattr(server, "tavily_extract", slow_failing_tavily)
+    monkeypatch.setattr(server, "firecrawl_scrape", failing_firecrawl)
+
+    assert await server._hedged_fetch("https://x.com") is None
+
+
+# ---------- 模型缓存 ----------
+
+@pytest.mark.asyncio
+async def test_models_cache_hits_within_ttl(monkeypatch):
+    calls = 0
+
+    async def fake_fetch(api_url, api_key):
+        nonlocal calls
+        calls += 1
+        return ["m1", "m2"]
+
+    monkeypatch.setattr(server, "_fetch_available_models", fake_fetch)
+    assert await server._get_available_models_cached("u", "k") == ["m1", "m2"]
+    assert await server._get_available_models_cached("u", "k") == ["m1", "m2"]
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_models_cache_failure_not_cached(monkeypatch):
+    calls = 0
+
+    async def flaky_fetch(api_url, api_key):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("network down")
+        return ["m1"]
+
+    monkeypatch.setattr(server, "_fetch_available_models", flaky_fetch)
+    assert await server._get_available_models_cached("u", "k") == []
+    # 失败不写缓存，下一次调用应重新拉取并成功
+    assert await server._get_available_models_cached("u", "k") == ["m1"]
+    assert calls == 2
+
+
+# ---------- Tavily key failover ----------
+
+@pytest.mark.asyncio
+async def test_tavily_extract_fails_over_to_next_key(monkeypatch):
+    import grok_search.tavily_client as tc
+
+    monkeypatch.setenv("TAVILY_API_KEYS", "bad-key,good-key")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        auth = request.headers.get("Authorization", "")
+        if "bad-key" in auth:
+            return httpx.Response(429, json={"error": "rate limited"})
+        return httpx.Response(200, json={"results": [{"raw_content": "page content"}]})
+
+    mock_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(tc, "get_client", lambda: mock_client)
+
+    try:
+        result = await tc.tavily_extract("https://example.com")
+        assert result == "page content"
+        # bad-key 应已被冷却
+        assert kp._cooldown.get("bad-key", 0) > 0
+    finally:
+        await mock_client.aclose()


### PR DESCRIPTION
对 MCP 服务器做了一轮全面审查优化重构，目标是更快速、更精准。

## 更快速

- **共享 HTTP 连接池**（最大提速点）：新增 `http_client.py`，进程级共享 `httpx.AsyncClient`（连接池 + keep-alive）。此前 Grok/Tavily/Firecrawl 每次调用都新建客户端，每个请求都重做 TCP + TLS 握手；现在所有模块复用同一连接池。
- **`web_fetch` 对冲式抓取**：此前 Tavily 失败要等满 60 秒超时才轮到 Firecrawl。现在 Tavily 超过 `GROK_FETCH_HEDGE_DELAY`（默认 8 秒，可配）未返回就并行追加 Firecrawl，谁先出有效内容用谁、另一方立即取消。Tavily 在窗口内正常返回时行为不变，不多耗额度；设 `0` 可让两者始终并发。
- **`get_config_info` 探针并行化**：连接测试和默认模型 1-token 探针互相独立，改为 `asyncio.gather` 并发，总耗时减半。
- **日志零开销**：`log_info` 此前不论 debug 是否开启都对每条消息发一次 MCP 通知（含整段搜索结果正文），现在非 debug 路径直接返回。

## 更精准

- **修复 `extra_sources` 分配 bug**：`round(extra_sources * 1)` 导致双引擎都配置时 Tavily 永远分到 0 条。现在对半分（Firecrawl 拿多的那半），补充信源覆盖两个独立搜索引擎。
- **补全多 key failover**：`tavily_extract` / `tavily_search` / `tavily_map` / `firecrawl_search` 遇 401/403/429 此前直接放弃整次请求，现在自动冷却当前 key 并换下一个重试。
- **模型缓存修复**：此前 `/models` 一次拉取失败就把空列表缓存到进程结束，模型校验从此永久失效。现在失败不写缓存，成功结果带 10 分钟 TTL。

## 重构清理

- `web_search` 并发结果改用命名 task 获取，去掉易错的 gather 位置索引
- `server.py` 散落的局部 `import json/httpx/time` 提升到模块顶部
- 提炼可单测的 `_split_extra_counts` / `_hedged_fetch` 辅助函数
- `.env.example` 与中英 README 同步新增 `GROK_FETCH_HEDGE_DELAY` 说明

## 测试

- 新增 `tests/test_optimizations.py`：对冲三种路径（Tavily 快胜 / 慢被 Firecrawl 反超 / 快速失败立即降级）、`extra_sources` 分配、模型缓存 TTL 与失败不缓存、Tavily key failover（MockTransport 验证 429 换 key）
- 全套 **33 个测试通过**（原 24 + 新增 9）
- 无 key 环境下用 FastMCP 客户端做了端到端冒烟：8 个工具全部注册，`web_fetch` / `web_search` / `get_sources` 错误路径返回正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ho2amJYgK5q4ScetDqWdJx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho2amJYgK5q4ScetDqWdJx)_